### PR TITLE
fix: "pseudo" is also used in refseq gff annotations.

### DIFF
--- a/src/c/breseq/reference_sequence.cpp
+++ b/src/c/breseq/reference_sequence.cpp
@@ -1568,8 +1568,11 @@ void cReferenceSequences::VerifyFeatureLocations()
         feature.m_gff_attributes["Pseudo"] = make_vector<string>("true");
         feature["type"] = "CDS";
       }
-      if (feature.m_gff_attributes.count("Pseudo"))
-        feature.m_pseudo = from_string<bool>(feature.m_gff_attributes["Pseudo"][0]);
+      if (feature.m_gff_attributes.count("Pseudo")) {
+         feature.m_pseudo = from_string<bool>(feature.m_gff_attributes["Pseudo"][0]);
+       } else if (feature.m_gff_attributes.count("pseudo")) {
+         feature.m_pseudo = from_string<bool>(feature.m_gff_attributes["pseudo"][0]);
+       }
       
       // Load translation table over to the gene
       if (feature.m_gff_attributes.count("transl_table"))


### PR DESCRIPTION
eg. https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/007/565/GCF_000007565.2_ASM756v2/GCF_000007565.2_ASM756v2_genomic.gff.gz

Originally only "Pseudo" is recognized.