### PR TITLE
Deprecate gdtools GD2VCF/VCF2GD/GD2GVF in favor of CONVERT

### DIFF
--- a/src/c/breseq/gdtools_cmdline.cpp
+++ b/src/c/breseq/gdtools_cmdline.cpp
@@ -52,9 +52,7 @@ int gdtools_usage()
   uout << "NOT-EVIDENCE           remove evidence not used by any mutations" << endl;
 	
   uout("Format Conversions:");
-  uout << "GD2VCF                 GD to Variant Call Format (VCF)" << endl;
-	uout << "VCF2GD                 Variant Call Format(VCF) to GD" << endl;
-  uout << "GD2GVF                 GD to Genome Variation Format (GVF)" << endl;
+  uout << "CONVERT                convert between GD, VCF, GVF, and JSON formats" << endl;
 	uout << "MUMMER2MASK            Create a mask GD file from MUMmer output" << endl;
 
 	uout("Analysis:");
@@ -704,6 +702,14 @@ int do_convert(int argc, char* argv[], string forced_format = "")
 	}
 	
 	return 0;
+}
+
+void print_convert_shortcut_deprecation_warning(const string& old_command, const string& new_format, int argc_new, char* argv_new[])
+{
+	vector<string> args(argv_new + 1, argv_new + argc_new);
+	WARN("The '" + old_command + "' command is deprecated and will be removed in a future version of gdtools.\n"
+	     "Use the equivalent CONVERT command instead:\n"
+	     "  gdtools CONVERT -f " + new_format + " " + join(args, " "));
 }
 
 int do_not_evidence(int argc, char *argv[])
@@ -2798,10 +2804,13 @@ int main(int argc, char* argv[]) {
 	} else if (command == "CONVERT") {
 		return do_convert(argc_new, argv_new.data());
   } else if (command == "GD2VCF") {
+    print_convert_shortcut_deprecation_warning(command, "VCF", argc_new, argv_new.data());
     return do_convert(argc_new, argv_new.data(), "VCF");
   } else if (command == "VCF2GD") {
+    print_convert_shortcut_deprecation_warning(command, "GD", argc_new, argv_new.data());
     return do_convert(argc_new, argv_new.data(), "GD");
   } else if (command == "GD2GVF") {
+    print_convert_shortcut_deprecation_warning(command, "GVF", argc_new, argv_new.data());
     return do_convert(argc_new, argv_new.data(), "GVF");
   } else if(command == "HEADER"){
     return do_header(argc_new, argv_new.data());


### PR DESCRIPTION
These shortcuts just call do_convert() with a hardcoded format and duplicate CONVERT -f <format>. Keep them working, but hide them from help and print a deprecation warning with the equivalent CONVERT command line when used.